### PR TITLE
More mobile updates

### DIFF
--- a/BassLines.Web/src/routes/home/SongCard.tsx
+++ b/BassLines.Web/src/routes/home/SongCard.tsx
@@ -93,7 +93,7 @@ export default function SongCard(props: IProps) {
 
   const spotifyProps = {
     ...props,
-    iconSize: isSmallScreen ? "14px" : "20px",
+    iconSize: "20px",
   };
 
   const spotifyActionLocation = {
@@ -205,13 +205,20 @@ export default function SongCard(props: IProps) {
         <SpotifyActions {...spotifyProps} />
       </Box>
       <Box
-        sx={{ position: "absolute", top: "0", right: "35%", marginTop: "-2px" }}
+        sx={{ 
+          position: "absolute", 
+          top: { xs: "-16px", md: "0" }, 
+          right: { xs: "40%", md: "35%"}
+         }}
         className={classes.root}
       >
         {props.song?.rating ? (
           <>
             <SvgIcon
-              sx={{ width: "62px", height: "102px" }}
+              sx={{ 
+                height: "102px",
+                width: { xs: "40px", md: "62px" }, 
+              }}
               viewBox="0 0 62 101"
               xmlns="http://www.w3.org/2000/svg"
             >
@@ -357,13 +364,13 @@ const SpotifyActions = ({
                 })
                 .catch(console.warn)
             }
-            sx={{ "& svg": { fontSize: iconSize } }}
+            sx={{ padding: "2px", "& svg": { fontSize: iconSize } }}
             children={<PlayArrowRounded />}
           />
           <IconButton
             disableRipple
             onClick={() => toggleSaved(spotifyTrackId, !song.saved)}
-            sx={{ "& svg": { fontSize: iconSize } }}
+            sx={{ padding: "2px", "& svg": { fontSize: iconSize } }}
             children={
               song.saved === undefined ? null : song.saved ? (
                 <FavoriteRounded htmlColor={theme.palette.secondary.main} />
@@ -381,14 +388,14 @@ const SpotifyActions = ({
                 })
                 .catch(console.warn)
             }
-            sx={{ "& svg": { fontSize: iconSize } }}
+            sx={{ padding: "2px", "& svg": { fontSize: iconSize } }}
             children={<AddRounded />}
           />
         </>
       )}
       <IconButton
         sx={{
-          "& svg": { fontSize: iconSize },
+          padding: "2px", "& svg": { fontSize: iconSize },
           color:
             song.likes.map((m) => m.userId).indexOf(userInfo.id) > -1
               ? "secondary.main"

--- a/BassLines.Web/src/routes/home/index.tsx
+++ b/BassLines.Web/src/routes/home/index.tsx
@@ -411,11 +411,17 @@ const HomeDashboard = React.memo((props: IHomeDashboardProps) => {
             </FormControl>
           </Grid>
         </Grid>
-        {profile?.premium && (
+        {profile?.premium && !!uris.length && (
           <Button
             variant="contained"
-            disabled={!uris.length}
-            sx={{ color: "#50d292" }}
+            sx={{ 
+              color: "#50d292", 
+              mt: 1, 
+              zIndex: 1,
+              width: { xs: "100%", sm: "fit-content" },
+              position: { xs: "sticky", sm: "unset" },
+              top: { xs: "32px", sm: "unset" },
+             }}
             onClick={async () => {
               callSpotify(SpotifyApi)
                 .apiSpotifyPlayPut({
@@ -434,10 +440,7 @@ const HomeDashboard = React.memo((props: IHomeDashboardProps) => {
             />
           </Button>
         )}
-        <Box
-          sx={{ height: "calc(100vh - 312px)", overflowY: "auto" }}
-          className={classes.scrollbar}
-        >
+        <Box className={classes.scrollbar} sx={{ pb: 2 }}>
           {sortedSongs.map((m: SongModel, i: number) => (
             <SongCard
               key={i}
@@ -456,7 +459,7 @@ const HomeDashboard = React.memo((props: IHomeDashboardProps) => {
           <Box
             sx={{
               position: "absolute",
-              top: "85%",
+              bottom: "125px",
               left: isSmallScreen ? "85%" : "95%",
             }}
           >

--- a/BassLines.Web/src/routes/spotify/ControlPanel/index.tsx
+++ b/BassLines.Web/src/routes/spotify/ControlPanel/index.tsx
@@ -244,7 +244,7 @@ export default React.memo(function ControlPanel() {
 
   return !player ? (
     <></>
-  ) : (
+  ) : track_window && playbackState ? (
     <>
       <Grid
         component="aside"
@@ -268,73 +268,66 @@ export default React.memo(function ControlPanel() {
         }}
       >
         <Grid item xs={12} md={4}>
-          {track_window || playbackState ? (
-            <Grid container justifyContent="space-between">
-              <SongItem
-                icon={
-                  currentTrack && (
-                    <IconButton
-                      disableRipple
-                      sx={{ p: "2px 0 0" }}
-                      onClick={() =>
-                        callSpotify(SpotifyApi)
-                          .apiSpotifySaveOrRemoveIdPut({
-                            id: currentTrack?.id,
-                            save: !currentTrack?.saved,
-                          })
-                          .then(setCurrentTrack)
-                          .catch(console.warn)
-                      }
-                      children={
-                        currentTrack?.saved ? (
-                          <Tooltip title="Remove from your Spotify library">
-                            <FavoriteRounded
-                              fontSize="small"
-                              style={{ color: theme.palette.secondary.main }}
-                            />
-                          </Tooltip>
-                        ) : (
-                          <Tooltip title="Add to your Spotify library">
-                            <FavoriteBorderRounded fontSize="small" />
-                          </Tooltip>
-                        )
-                      }
-                    />
-                  )
-                }
-                style={{
-                  width: "fit-content",
-                  marginRight: "8px",
-                  maxWidth: "100%",
-                }}
-                song={{
-                  title: (track_window?.current_track ?? playbackState?.item)
-                    ?.name,
-                  artist: (track_window?.current_track ?? playbackState?.item)
-                    ?.artists?.[0]?.name,
-                  images: (track_window?.current_track ?? playbackState?.item)
-                    ?.album?.images,
-                }}
-                element="div"
-              />
-              {isSmall && (
-                <Grid item container sx={{ width: "fit-content" }}>
-                  {prevButton()}
-                  {playButton()}
-                  {nextButton()}
-                </Grid>
-              )}
-            </Grid>
-          ) : playerState?.loading ? (
-            <CircularProgress size={28} />
-          ) : (
-            <Box width={"180px"} />
-          )}
+          <Grid container wrap='nowrap' justifyContent="space-between">
+            <SongItem
+              icon={
+                currentTrack && (
+                  <IconButton
+                    disableRipple
+                    sx={{ p: "2px 0 0" }}
+                    onClick={() =>
+                      callSpotify(SpotifyApi)
+                        .apiSpotifySaveOrRemoveIdPut({
+                          id: currentTrack?.id,
+                          save: !currentTrack?.saved,
+                        })
+                        .then(setCurrentTrack)
+                        .catch(console.warn)
+                    }
+                    children={
+                      currentTrack?.saved ? (
+                        <Tooltip title="Remove from your Spotify library">
+                          <FavoriteRounded
+                            fontSize="small"
+                            style={{ color: theme.palette.secondary.main }}
+                          />
+                        </Tooltip>
+                      ) : (
+                        <Tooltip title="Add to your Spotify library">
+                          <FavoriteBorderRounded fontSize="small" />
+                        </Tooltip>
+                      )
+                    }
+                  />
+                )
+              }
+              style={{
+                width: "calc(100% - 125px)",
+                marginRight: "8px",
+              }}
+              song={{
+                title: (track_window?.current_track ?? playbackState?.item)
+                  ?.name,
+                artist: (track_window?.current_track ?? playbackState?.item)
+                  ?.artists?.[0]?.name,
+                images: (track_window?.current_track ?? playbackState?.item)
+                  ?.album?.images,
+              }}
+              element="div"
+            />
+            {isSmall && (
+              <Grid item container sx={{ width: "fit-content" }}>
+                {prevButton()}
+                {playButton()}
+                {nextButton()}
+              </Grid>
+            )}
+          </Grid>
 
           {isSmall && (
             <Grid container>
               <Slider
-                sx={{ flexGrow: 1, padding: "6px 0 0" }}
+                sx={{ flexGrow: 1, padding: "6px 0 0 !important" }}
                 color="secondary"
                 size="medium"
                 disabled={playingExternally}
@@ -502,7 +495,8 @@ export default React.memo(function ControlPanel() {
             />
           }
         />
-        {playingExternally &&
+        {!isSmall &&
+          playingExternally &&
           playbackState?.device?.name &&
           playbackState?.device?.name !== "BassLines" && (
             <Grid
@@ -537,6 +531,8 @@ export default React.memo(function ControlPanel() {
         />
       )}
     </>
+  ) : (
+    <></>
   );
 });
 

--- a/BassLines.Web/src/toolbar/index.tsx
+++ b/BassLines.Web/src/toolbar/index.tsx
@@ -68,18 +68,18 @@ const AppBar = styled(MuiAppBar)(({ theme }) => ({
   zIndex: theme.zIndex.drawer + 1,
 }));
 
-const Drawer = styled(MuiDrawer, {
-  shouldForwardProp: (prop) => prop !== "open",
-})<DrawerProps>(({ theme, open }) => ({
-  ...(!open && {
-    ...closedMixin(theme),
-    "& .MuiDrawer-paper": closedMixin(theme),
-  }),
-  ...(open && {
-    ...openedMixin(theme),
-    "& .MuiDrawer-paper": openedMixin(theme),
-  }),
-}));
+// const Drawer = styled(MuiDrawer, {
+//   shouldForwardProp: (prop) => prop !== "open",
+// })<DrawerProps>(({ theme, open }) => ({
+//   ...(!open && {
+//     ...closedMixin(theme),
+//     "& .MuiDrawer-paper": closedMixin(theme),
+//   }),
+//   ...(open && {
+//     ...openedMixin(theme),
+//     "& .MuiDrawer-paper": openedMixin(theme),
+//   }),
+// }));
 
 const StatBox = styled(Box)(({ theme }) => ({
   display: "flex",
@@ -231,10 +231,15 @@ export default function MiniDrawer(props: IMiniDrawerProps) {
           />
         </Toolbar>
       </AppBar>
-      <Drawer
-        variant="permanent"
+      <MuiDrawer
+        variant={isSmallScreen ? "temporary" : "permanent"}
         PaperProps={{
-          sx: { boxShadow: "-2px 0 6px -1px rgb(0, 0, 0, .20) inset" },
+          sx: { 
+            width: isSmallScreen ? "100vw" : drawerWidth,
+            maxWidth: "500px",
+            boxShadow: "-2px 0 6px -1px rgb(0, 0, 0, .20) inset" ,
+            position: isSmallScreen ? "fixed" : "relative",
+          },
         }}
         open={!isSmallScreen || menuOpen}
       >
@@ -428,7 +433,7 @@ export default function MiniDrawer(props: IMiniDrawerProps) {
         >
           Logout
         </Button>
-      </Drawer>
+      </MuiDrawer>
       <Box
         component="main"
         sx={{

--- a/BassLines.Web/src/toolbar/index.tsx
+++ b/BassLines.Web/src/toolbar/index.tsx
@@ -68,19 +68,6 @@ const AppBar = styled(MuiAppBar)(({ theme }) => ({
   zIndex: theme.zIndex.drawer + 1,
 }));
 
-// const Drawer = styled(MuiDrawer, {
-//   shouldForwardProp: (prop) => prop !== "open",
-// })<DrawerProps>(({ theme, open }) => ({
-//   ...(!open && {
-//     ...closedMixin(theme),
-//     "& .MuiDrawer-paper": closedMixin(theme),
-//   }),
-//   ...(open && {
-//     ...openedMixin(theme),
-//     "& .MuiDrawer-paper": openedMixin(theme),
-//   }),
-// }));
-
 const StatBox = styled(Box)(({ theme }) => ({
   display: "flex",
   flexDirection: "column",


### PR DESCRIPTION
Made some UI adjustments (mostly on mobile)
- Card list no longer has a fixed height
- Score banner is now smaller on mobile to prevent it covering action buttons
- Prevent the Spotify player text from wrapping, and make it a little smaller
- Make the drawer temporary on mobile, to prevent layout shifting
- Don't show "Playing On" footer when mobile (too bulky)